### PR TITLE
Fix error on load_pem_private_key

### DIFF
--- a/app/server_platform.py
+++ b/app/server_platform.py
@@ -15,8 +15,8 @@ from typing import Union
 from multidict import CIMultiDict
 
 from cryptography.utils import int_to_bytes
-from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.serialization import load_pem_private_key
 from cryptography.hazmat.primitives.asymmetric import ec, padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
@@ -143,8 +143,6 @@ class ServerPlatform:
     OB_CERTS_DIR = os.path.abspath(
         os.environ.get("OB_CERTS_DIR", "/app/open_banking_certs")
     )
-
-    hazmat_backend = default_backend()
 
     def _get_ob_certs_file_path(self, path: str) -> str:
         abspath = os.path.abspath(os.path.join(self.OB_CERTS_DIR, path))
@@ -311,7 +309,7 @@ class ServerPlatform:
             )
 
         data = self._force_bytes(data)
-        key = self.hazmat_backend.load_pem_private_key(
+        key = load_pem_private_key(
             open(self._get_ob_certs_file_path(key_path), "rb").read(),
             (lambda p: p.encode("utf-8") if p is not None else None)(
                 _read_key_password(key_path)


### PR DESCRIPTION
Hello,
We setup eidasbroker using docker image `ghcr.io/enablebanking/eidas_broker:12` and while making some tests, we encountered an error when we tried to call /sign

We managed to make it work with this change directly inside the container.

Before change :
```
root@3c7ffd77bad2:/# curl https://localhost:80/sign --key certs/client.key --cert certs/client.crt --cacert certs/ca.crt -X POST -H "Content-Type: application/json" -d '{ "params": { "data": "test", "key_id": "example.key", "crypto_algorithm": "PS" }}'
{"code":500,"message":"Internal server error","data":"'Backend' object has no attribute 'load_pem_private_key'"}

```

After change :
```
root@3c7ffd77bad2:/# curl https://localhost:80/sign --key certs/client.key --cert certs/client.crt --cacert certs/ca.crt -X POST -H "Content-Type: application/json" -d '{ "params": { "data": "test", "key_id": "example.key", "crypto_algorithm": "PS" }}'
{"result":"RFFzGGU/hVB/a2kpML1qmhBwhA/Sg/ysLG53p+yFER0cMokKI39cn/5sxkRw/+b0ZnHPe3LeDme8LAvMMAfSqx+BA5iVOGu3JOH//dABrwqVDlErjLARgupFCjcxg6io2n2jJVcvJ0dLXTdPBeH7YMDPtZt4qAJPhbcPgD4CnTUjCek0MT1qtqW97+uLyqLJfF47DoK3HVF91L7ZECXoxHEpHtN6xso1NVWccvqigicAu6AAjwwIauE3OjMZ0szy94OfSmpDpjxgbEjqJNN64XvR2LzfbBHc1+CrYPrm0kP+KVXTUPkjnhb64nFCipH4I8Z58c1u7p09DupoVGfkMngFRTQzV245J9Cdr78JseeefZidBqoVzFrsVGXht38VGeC7DoOea+uetDDyxi17CK76UFk34miRhUcWR/MGLC2ps1+U7tRoeKbEbJsYiy98jYJdI5m7GIgpWiRE33Ft7R22mLEz7NYnkJAml9CUif6PHilHjo4VnhQnQH9T/iai9LNhRniI4tiwhODFhECi2ew0bJ3meXBKzRZm+P/CZCmQf9X7qQuxawgDfoDweSDQ1mobB/AcrTBZpcNXNsKAVepmieATzVCgnrz2RDp9N/RJLFM/rkPFIKWzM/WbEc7uxEy0wTrrYfQfM7+PYlWRwuhSuONE61mkg9i4PSB174M="}
```