### PR TITLE
Always creating default SSL context

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,9 +191,6 @@ In order to build an image you need to:
        --mount type=bind,source="$(pwd)"/broker_tls/,target=/app/broker_tls/ \
        <image_name>
    ```
-
-   You can also specify `verify_cert` environment variable using `-e` flag if you want you requests to
-   ASPSPs to be verified against QWAC certificate chain (if it is provided).
 8. You can verify that the service is running correctly by running the following command:
 
    ```

--- a/app/server_platform.py
+++ b/app/server_platform.py
@@ -160,14 +160,10 @@ class ServerPlatform:
             ssl_context.maximum_version = forced_tls_version
 
     def get_ssl_context(self, tls: TLS | None) -> ssl.SSLContext:
+        ssl_context = ssl.create_default_context()
         if tls:
-            ssl_context = ssl.create_default_context()
             ssl_context = self.key_loader.update_ssl_context(ssl_context, tls)
-            ssl_context.check_hostname = False
-            ssl_context.verify_mode = ssl.CERT_NONE
             self._set_tls_version_for_ssl_context(ssl_context, tls.tls_version)
-        else:
-            ssl_context = ssl._create_unverified_context()
         return ssl_context
 
     def _handle_binary_response(self, response: bytes) -> bytes:


### PR DESCRIPTION
With this change we'll always use default SSL context (https://docs.python.org/3/library/ssl.html#ssl.create_default_context) to use [the best defaults](https://docs.python.org/3/library/ssl.html#best-defaults).