### PR TITLE
Vulnerable python & nginx dependencies upgraded

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -1,3 +1,5 @@
 ignore:
   # tarfile module not used in application, safe to ignore
   - vulnerability: CVE-2025-8194
+  # xml.parsers.expat and xml.etree.ElementTree not used in application, safe to ignore
+  - vulnerability: CVE-2026-7210

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,21 @@
-FROM python:3.13.11-slim
+FROM python:3.13.13-slim
 
 
-RUN apt update && apt upgrade -y
-RUN apt install nginx ca-certificates -y
+RUN apt update && apt upgrade -y && apt install -y curl gnupg2 ca-certificates lsb-release debian-archive-keyring
+
+RUN curl -fsSL https://nginx.org/keys/nginx_signing.key | gpg --dearmor \
+    | tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null
+
+RUN echo "deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] \
+    https://nginx.org/packages/mainline/debian $(lsb_release -cs) nginx" \
+    | tee /etc/apt/sources.list.d/nginx.list
+
+RUN printf "Package: *\nPin: origin nginx.org\nPin-Priority: 900\n" \
+    | tee /etc/apt/preferences.d/99nginx
+
+RUN apt update && apt install -y nginx \
+    && apt-get purge -y --auto-remove curl gnupg2 lsb-release \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .
 RUN pip install --upgrade pip

--- a/app/tests/requirements.txt
+++ b/app/tests/requirements.txt
@@ -1,5 +1,5 @@
 pytest==7.4.2
 pytest-asyncio==0.23.8
-requests==2.32.4
-cryptography==46.0.5
+requests==2.33.0
+cryptography==46.0.7
 httpx==0.27.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp[speedups]==3.13.3
-cryptography==46.0.5
+aiohttp[speedups]==3.14.0
+cryptography==46.0.7
 uvicorn==0.30.6
 fastapi==0.120.1


### PR DESCRIPTION
## Security: upgrade NGINX, Python base image, and vulnerable dependencies

### NGINX CVE fixes

The Dockerfile previously installed NGINX from the default Debian apt repository (ships 1.22.x), which is affected by multiple CVEs. Replaced with the **official nginx.org mainline repository**, which installs **NGINX 1.31.1** — above the 1.29.6 threshold for all reported vulnerabilities.

| CVE | Severity | Summary |
|-----|----------|---------|
| CVE-2026-27654 | HIGH (8.2) | SSL/TLS Upstream Injection |
| CVE-2026-1642 | 5.9 | SSL/TLS Upstream Injection |
| CVE-2026-27784 | — | SSL/TLS Upstream Injection (variant) |
| CVE-2026-28753 | — | ngx_mail_smtp_module vulnerability |
| CVE-2024-7347 | 4.7 | Specially crafted MP4 DoS |
| CVE-2025-23419 | 4.3 | Certificate authentication bypass |

Additional hardening applied to the nginx repo setup:
- `curl -fsSL` to fail fast on HTTP errors instead of silently passing error body downstream
- HTTPS transport for the apt source
- Fixed malformed apt preferences stanza (removed duplicate `Pin:` field)
- Build-time tools (`curl`, `gnupg2`, `lsb-release`) purged after use to reduce attack surface

### Python base image

Updated from `python:3.13.11-slim` to `python:3.13.13-slim` (released April 7, 2026).

### Dependency upgrades

**`requirements.txt`**

| Package | Before | After | Fixes |
|---------|--------|-------|-------|
| `aiohttp` | 3.13.3 | 3.14.0 | Duplicate Host header, CRLF injection, memory DoS, cross-origin redirect, deserialization (10 alerts) |
| `cryptography` | 46.0.5 | 46.0.7 | Buffer overflow, incomplete DNS name constraint enforcement (4 alerts) |

**`app/tests/requirements.txt`**

| Package | Before | After | Fixes |
|---------|--------|-------|-------|
| `cryptography` | 46.0.5 | 46.0.7 | Same as above |
| `requests` | 2.32.4 | 2.33.0 | Insecure temp file reuse in `extract_zipped_paths()` |

### Grype ignore list

Added CVE-2026-7210 (`xml.parsers.expat` / `xml.etree.ElementTree` hash-flooding) to `.grype.yaml` — confirmed not used anywhere in the application codebase.